### PR TITLE
ampliar el try/catch en conflictos con las migraciones

### DIFF
--- a/accounts/custom_filters.py
+++ b/accounts/custom_filters.py
@@ -49,7 +49,7 @@ class CollaborationFilter(django_filters.ChoiceFilter):
         try:
             collabs =  Collaboration.objects.all()
             choices = list(collabs.values_list('pk', 'name'))
-        except db.utils.ProgrammingError as e:
+        except (db.utils.ProgrammingError, db.utils.OperationalError) as e:
             print("Pending migrations for CollaborationFilter")
 
         django_filters.ChoiceFilter.__init__(self, choices=choices, *args,**kwargs)

--- a/accounts/views/entity.py
+++ b/accounts/views/entity.py
@@ -5,6 +5,7 @@ import django_filters
 from django.conf import settings
 from django.contrib import messages
 from django.db.models import Q
+from django import db
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.generic import UpdateView, CreateView
@@ -51,7 +52,10 @@ class EntityFilter(django_filters.FilterSet):
 class EntitiesListView(FilterMixin, FilterView, ExportAsCSVMixin, ListItemUrlMixin, AjaxTemplateResponseMixin):
 
     model = Entity
-    queryset = Entity.objects.filter( Q(instance_of=Colaborator) | Q(collabs__isnull=False) ).distinct()
+    try:
+        queryset = Entity.objects.filter( Q(instance_of=Colaborator) | Q(collabs__isnull=False) ).distinct()
+    except (db.utils.ProgrammingError, db.utils.OperationalError) as e:
+        print("Pending migrations")
     objects_url_name = 'entity_detail'
     template_name = 'entity/list.html'
     ajax_template_name = 'entity/query.html'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-tastypie==0.14.2
 fcm-django==0.2.13
 idna==2.7
 libsass==0.15.0
-mysqlclient==1.3.12
+mysqlclient
 olefile==0.45.1
 pilkit==2.0
 Pillow==4.2.1
@@ -29,7 +29,7 @@ requests==2.20.0
 requests-toolbelt==0.8.0
 rjsmin==1.0.12
 selenium==3.141.0
-six==1.11.0
+six
 sepaxml==2.2.0
 WeasyPrint==52.4
 webdriver-manager==2.4.0

--- a/simple_bpm/custom_filters.py
+++ b/simple_bpm/custom_filters.py
@@ -26,7 +26,7 @@ class WorkflowFilter(django_filters.ChoiceFilter):
                 processes = Process.objects.all().values_list('pk', flat=True)
             self.steps = ProcessStep.objects.filter(process__in=processes)
             choices = list(self.steps.values_list('pk', 'title'))
-        except db.utils.ProgrammingError as e:
+        except (db.utils.ProgrammingError, db.utils.OperationalError) as e:
             print("Pending migrations for WorkflowFilter")
 
         if filter_cancelled:


### PR DESCRIPTION
Hola!

He probado vuestra app para ver qué tal y poder usarla en el Mercao Social de Córdoba, y he tenido varios problemas para ponerla en marcha.

Este ha sido que los chequeos que pusisteis cuando hubiera código que tirara de datos antes de que se hubieran podido realizar las migraciones no estaban capturando los fallos en mi instalación!
En mi caso que he puesto una base de datos sqlite para probar (no sé si es por eso) me estaba lanzando excepciones de OperationalError, no de ProgrammingError como teníais hasta ahora. 

Si le agrego que capture también esa excepción puedo crear las migracines y ejecutar la app finalmente sin problema.

espero que pueda ser útil
un saludo, gracias y ánimo!